### PR TITLE
maven-bundle-plugin must be defined as extension

### DIFF
--- a/en/developer-guide/creating-a-new-roboconf-plugin.md
+++ b/en/developer-guide/creating-a-new-roboconf-plugin.md
@@ -67,6 +67,7 @@ At the moment this documentation is being written, there is not yet a Roboconf p
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>2.4.0</version>
+				<extensions>true</extensions>
 				<configuration>
 					<instructions>
 						<Import-Package>


### PR DESCRIPTION
otherwise we get the error: "Unknown packaging: bundle"
